### PR TITLE
Fix progress bar width in batch testing

### DIFF
--- a/app/(main-layout)/port-checker/test/TestPortCheckerPage.tsx
+++ b/app/(main-layout)/port-checker/test/TestPortCheckerPage.tsx
@@ -302,7 +302,7 @@ export function TestPortCheckerPage() {
                     <div className="mb-6 h-2 w-full rounded-full">
                         <div
                             className="h-2 rounded-full border"
-                            style={{ width: `${(currentBatchTestIndex / testCases.length) * 100}%` }}
+                            style={{ width: `${((currentBatchTestIndex + 1) / testCases.length) * 100}%` }}
                         ></div>
                     </div>
                     <div className="mb-4 grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- ensure the batch test progress bar reaches 100%

## Testing
- `npm run typecheck` *(fails: Missing script)*
- `npm run lint` *(fails to find `@eslint/js`)*