### PR TITLE
Fix Tailwind config references

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ In this project, we are utilizing Next.js `App Router`. The `App Router` determi
 
 ## Styling with Tailwind CSS
 
-This project uses Tailwind CSS, a utility-first CSS framework, for styling. The configuration file for Tailwind CSS is `tailwind.config.js`. As part of the development process, you may need to customize this file according to your feature needs.
+This project uses Tailwind CSS, a utility-first CSS framework, for styling. The configuration file for Tailwind CSS is `tailwind.config.ts`. As part of the development process, you may need to customize this file according to your feature needs.
 
 ## More Resources
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,5 @@
 // Dependencies - Project
-// Have to use relative paths for tailwind.config.js
+// Have to use relative paths for tailwind.config.ts
 // import ProjectSettings from './ProjectSettings';
 import StructureTailwindConfiguration from './libraries/structure/source/theme/TailwindConfiguration';
 


### PR DESCRIPTION
## Summary
- update README to reference `tailwind.config.ts`
- tweak header comment in `tailwind.config.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find package '@eslint/js')*