### PR TITLE
Fix typo maxAttemps

### DIFF
--- a/app/(main-layout)/port-checker/history/PortCheckerHistoryPage.tsx
+++ b/app/(main-layout)/port-checker/history/PortCheckerHistoryPage.tsx
@@ -45,7 +45,7 @@ interface PortCheckFlowStepExecutionInputInterface {
     host: string;
     port: number; // Required in GraphQL response
     region: string; // Region ID in GraphQL response
-    maxAttempts: number; // Note: GraphQL response has 'maxAttempts' not 'maxAttemps'
+    maxAttempts: number; // GraphQL field name is 'maxAttempts'
 }
 
 // Type - PortCheckFlowOutputInterface

--- a/source/modules/connected/port-check/PortCheckFlowService.ts
+++ b/source/modules/connected/port-check/PortCheckFlowService.ts
@@ -110,7 +110,7 @@ export interface PortCheckFlowInputInterface {
     host: string;
     port?: number;
     country?: string;
-    maxAttemps?: number;
+    maxAttempts?: number;
 }
 
 // Server Type - PortCheckFlowOutputInterface - Output for a port scan flow


### PR DESCRIPTION
## Summary
- rename `maxAttemps` to `maxAttempts` in the PortCheck flow interface
- update history page comment

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find package '@eslint/js')*